### PR TITLE
Fix: Security group allows public access to port 22, which should be restricted to a private IP range.


### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,12 +17,12 @@ resource "aws_security_group" "example" {
   name        = "example-sg"
   description = "Security group for EC2 instance with open ports"
 
-  # SSH access from anywhere
+  # SSH access from the provided private range only
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["xx.xx.xx.xx/xx"] # replace with the provided private IP range
   }
 
   # HTTP access from anywhere


### PR DESCRIPTION
This PR addresses the issue: "Security group allows public access to port 22, which should be restricted to a private IP range.
"

Changes made in terraform/ec2.tf.