### PR TITLE
Fix: Security group allows public access to port 22, which should be restricted to a private IP range.

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,12 +17,12 @@ resource "aws_security_group" "example" {
   name        = "example-sg"
   description = "Security group for EC2 instance with open ports"
 
-  # SSH access from anywhere
+  # SSH access from a specific IP range (replace x.x.x.x/xx with your private IP range)
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["x.x.x.x/xx"]
   }
 
   # HTTP access from anywhere


### PR DESCRIPTION
This PR addresses the issue: "Security group allows public access to port 22, which should be restricted to a private IP range."

Changes made in terraform/ec2.tf.