### PR TITLE
Fix: {"_id":"681c2cfbdbf737adc3f9c684","instanceId":"i-08622141daa385fc1","subType":"Multiple","type":"PublicallyAccessibleEc2","severity":"Critical","message":"Found 1 risky ports open to the internet: SSH (22/tcp)","metricHistory":[{"timestamp":"2025-05-08T04:03:07.615Z","metrics":{"ports":[{"port":22,"protocol":"tcp","service":"SSH","exposedTo":["IPv4"],"securityGroups":[{"id":"sg-0eeb8febf5de13fab","name":"SSH-Only-SG-ezAXK3ud"}]}]},"_id":"681c2cfbdbf737adc3f9c685"}],"status":"active","firstDetectedAt":"2025-05-08T04:03:07.615Z","lastDetectedAt":"2025-05-10T10:05:18.626Z","createdAt":"2025-05-08T04:03:07.617Z","updatedAt":"2025-05-10T10:05:18.626Z","__v":0}

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,12 +17,12 @@ resource "aws_security_group" "example" {
   name        = "example-sg"
   description = "Security group for EC2 instance with open ports"
 
-  # SSH access from anywhere
+  # SSH access only from trusted network
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["trusted.network.ip/32"] # Replace "trusted.network.ip/32" with your trusted network IP range
   }
 
   # HTTP access from anywhere


### PR DESCRIPTION
This PR addresses the issue: "{"_id":"681c2cfbdbf737adc3f9c684","instanceId":"i-08622141daa385fc1","subType":"Multiple","type":"PublicallyAccessibleEc2","severity":"Critical","message":"Found 1 risky ports open to the internet: SSH (22/tcp)","metricHistory":[{"timestamp":"2025-05-08T04:03:07.615Z","metrics":{"ports":[{"port":22,"protocol":"tcp","service":"SSH","exposedTo":["IPv4"],"securityGroups":[{"id":"sg-0eeb8febf5de13fab","name":"SSH-Only-SG-ezAXK3ud"}]}]},"_id":"681c2cfbdbf737adc3f9c685"}],"status":"active","firstDetectedAt":"2025-05-08T04:03:07.615Z","lastDetectedAt":"2025-05-10T10:05:18.626Z","createdAt":"2025-05-08T04:03:07.617Z","updatedAt":"2025-05-10T10:05:18.626Z","__v":0}"

Changes made in terraform/ec2.tf.