### PR TITLE
Fix: {"_id":"681c2cfbdbf737adc3f9c690","instanceId":"i-0499948c6eadbfdc3","subType":"Multiple","type":"PublicallyAccessibleEc2","severity":"Critical","message":"Found 1 risky ports open to the internet: SSH (22/tcp)","metricHistory":[{"timestamp":"2025-05-08T04:03:07.712Z","metrics":{"ports":[{"port":22,"protocol":"tcp","service":"SSH","exposedTo":["IPv4"],"securityGroups":[{"id":"sg-0eeb8febf5de13fab","name":"SSH-Only-SG-ezAXK3ud"}]}]},"_id":"681c2cfbdbf737adc3f9c691"}],"status":"active","firstDetectedAt":"2025-05-08T04:03:07.712Z","lastDetectedAt":"2025-05-10T10:05:19.028Z","createdAt":"2025-05-08T04:03:07.712Z","updatedAt":"2025-05-10T10:05:19.028Z","__v":0}

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,12 +17,12 @@ resource "aws_security_group" "example" {
   name        = "example-sg"
   description = "Security group for EC2 instance with open ports"
 
-  # SSH access from anywhere
+  # SSH access from specific IP range
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["10.0.0.0/8"] # Update with your own IP range
   }
 
   # HTTP access from anywhere


### PR DESCRIPTION
This PR addresses the issue: "{"_id":"681c2cfbdbf737adc3f9c690","instanceId":"i-0499948c6eadbfdc3","subType":"Multiple","type":"PublicallyAccessibleEc2","severity":"Critical","message":"Found 1 risky ports open to the internet: SSH (22/tcp)","metricHistory":[{"timestamp":"2025-05-08T04:03:07.712Z","metrics":{"ports":[{"port":22,"protocol":"tcp","service":"SSH","exposedTo":["IPv4"],"securityGroups":[{"id":"sg-0eeb8febf5de13fab","name":"SSH-Only-SG-ezAXK3ud"}]}]},"_id":"681c2cfbdbf737adc3f9c691"}],"status":"active","firstDetectedAt":"2025-05-08T04:03:07.712Z","lastDetectedAt":"2025-05-10T10:05:19.028Z","createdAt":"2025-05-08T04:03:07.712Z","updatedAt":"2025-05-10T10:05:19.028Z","__v":0}"

Changes made in terraform/ec2.tf.